### PR TITLE
Remove script support

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -66,7 +66,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          run: dummy-command
+          run: cat < dummy-file
           post-on-success: |
             ## :white_check_mark: Success
             ```

--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -66,7 +66,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          run: cat < dummy-file
+          run: cat dummy-file
           post-on-success: |
             ## :white_check_mark: Success
             ```

--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -66,7 +66,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
-          run: false
+          run: dummy-command
           post-on-success: |
             ## :white_check_mark: Success
             ```

--- a/README.md
+++ b/README.md
@@ -95,16 +95,17 @@ jobs:
             ```
 ```
 
-You can use JavaScript based string interpolation in `post-on-success` and `post-on-failure`.
+You can use the string interpolation in `post-on-success` and `post-on-failure`.
 The following variables are available:
 
-- `run.output` (string)
+- `${run.output}`
   - combined output of the command
-- `run.lines` (array of strings)
-  - combined output of the command
-- `run.code` (number)
+- `${run.code}`
   - exit code of the command
 
+This action does not support any script to keep it simple and secure.
+You can still write a script by `actions/github-script`,
+but it would be a good chance to write your awesome action by a programming language.
 
 ## Inputs
 
@@ -119,10 +120,3 @@ The following variables are available:
 | `token` | `github.token` | GitHub token
 
 Either `post` or `run` must be set.
-
-
-## Outputs
-
-| Name | Description
-|------|------------
-| `example` | example output

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following variables are available:
 
 This action does not support any script to keep it simple and secure.
 You can still write a script by `actions/github-script`,
-but it would be a good chance to write your awesome action by a programming language.
+but it would be nice to write your awesome action by a programming language for maintainability.
 
 ## Inputs
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,8 +1,6 @@
-export const evaluateTemplate = (s: string, context: Record<string, unknown>): string => {
-  const escaped = 'return `' + s.replace(/`/g, '\\`') + '`'
-
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const fn = new Function(...Object.keys(context), escaped)
-
-  return String(fn(...Object.values(context)))
+export const replaceTemplate = (s: string, context: Record<string, string>): string => {
+  for (const [k, v] of Object.entries(context)) {
+    s = s.replaceAll(k, v)
+  }
+  return s
 }

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -1,22 +1,17 @@
-import { evaluateTemplate } from '../src/template'
+import { replaceTemplate } from '../src/template'
 
 test('plain text', () => {
-  expect(evaluateTemplate('foo', {})).toBe('foo')
+  expect(replaceTemplate('foo', {})).toBe('foo')
 })
 
 test('multiline text', () => {
-  expect(evaluateTemplate('foo\n```\ncode\n```\nbar', {})).toBe('foo\n```\ncode\n```\nbar')
+  expect(replaceTemplate('foo\n```\ncode\n```\nbar', {})).toBe('foo\n```\ncode\n```\nbar')
 })
 
 test('interpolation with variable', () => {
-  expect(evaluateTemplate('exit code ${code}, failed', { code: 2 })).toBe('exit code 2, failed')
+  expect(replaceTemplate('exit code ${code}, failed', { '${code}': '2' })).toBe('exit code 2, failed')
 })
 
-test('interpolation with expression', () => {
-  expect(evaluateTemplate('value ${value * 100}', { value: 3 })).toBe('value 300')
-})
-
-test('nested interpolation is not supported', () => {
-  expect(() => evaluateTemplate('value ${value * 10 + ` dollars`}', { value: 5 })).toThrowError(SyntaxError)
-  // toBe('value 50 dollars')
+test('interpolation with expression is not supported', () => {
+  expect(replaceTemplate('value ${value * 100}', {})).toBe('value ${value * 100}')
 })


### PR DESCRIPTION
## Problem to solve
Currently, this action depends on JavaScript eval and it may cause the script injection.

For long-term maintainability, it should be achieved by a dedicated action. Generally, do not write a complex script.
