### PR TITLE
Add `issue-number` input to specify issue or pull request

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -91,3 +91,11 @@ jobs:
           update-if-exists: append
           post: |
             :memo: This comment should be appended.
+
+      - if: github.event_name == 'pull_request'
+        name: With issue-number
+        uses: ./
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          post: |
+            :memo: `issue-number` input works

--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -21,6 +21,9 @@ on:
 jobs:
   ts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This action infers pull request(s) from the context as follows:
 - On `push` event, use pull request(s) associated with the current commit
 - Otherwise, get pull request(s) associated with `github.sha`
 
+You can also specify the issue or pull request number via `issue-number` input.
+
 ### Post a comment
 
 To post a comment:
@@ -117,6 +119,7 @@ but it would be nice to write your awesome action by a programming language for 
 | `run` | - | If set, run a command
 | `post-on-success` | (optional) | If set, post a comment on success of the command
 | `post-on-failure` | (optional) | If set, post a comment on failure of the command
+| `issue-number` | (optional) | Number of an issue or pull request on which to create a comment
 | `token` | `github.token` | GitHub token
 
 Either `post` or `run` must be set.

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,9 @@ inputs:
   post-on-failure:
     description: If set, post a comment on failure of the command
     required: false
+  issue-number:
+    description: Number of an issue or pull request on which to create a comment
+    required: false
   token:
     description: GitHub token
     required: true

--- a/src/command.ts
+++ b/src/command.ts
@@ -12,6 +12,7 @@ type Inputs = {
   postOnFailure: string
   updateIfExists: UpdateIfExistsType
   updateIfExistsKey: string
+  issueNumber: number | undefined
 }
 
 export const runCommand = async (octokit: Octokit, inputs: Inputs) => {
@@ -27,6 +28,7 @@ export const runCommand = async (octokit: Octokit, inputs: Inputs) => {
         body,
         updateIfExists: inputs.updateIfExists,
         updateIfExistsKey: inputs.updateIfExistsKey,
+        issueNumber: inputs.issueNumber,
       })
     }
     return
@@ -38,6 +40,7 @@ export const runCommand = async (octokit: Octokit, inputs: Inputs) => {
       body,
       updateIfExists: inputs.updateIfExists,
       updateIfExistsKey: inputs.updateIfExistsKey,
+      issueNumber: inputs.issueNumber,
     })
   }
   throw new Error(`Command exited with code ${result.code}`)

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -8,6 +8,7 @@ type Inputs = {
   body: string
   updateIfExists: UpdateIfExistsType
   updateIfExistsKey: string
+  issueNumber: number | undefined
 }
 
 export type UpdateIfExistsType = 'replace' | 'append' | undefined
@@ -19,6 +20,17 @@ type PullRequest = {
 }
 
 export const postComment = async (octokit: Octokit, inputs: Inputs) => {
+  if (inputs.issueNumber) {
+    const { context } = github
+    const pr = {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: inputs.issueNumber,
+    }
+    await createOrUpdateComment(octokit, pr, inputs)
+    return
+  }
+
   const pullRequests = await inferPullRequestsFromContext(octokit)
   for (const pullRequest of pullRequests) {
     await createOrUpdateComment(octokit, pullRequest, inputs)

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ const main = async (): Promise<void> => {
     run: core.getInput('run'),
     postOnSuccess: core.getInput('post-on-success'),
     postOnFailure: core.getInput('post-on-failure'),
+    issueNumber: issueNumber(core.getInput('issue-number')),
     token: core.getInput('token'),
   })
 }
@@ -22,6 +23,22 @@ const updateIfExists = (s: string): UpdateIfExistsType => {
     throw new Error(`update-if-exists must be replace or append`)
   }
   return s
+}
+
+const issueNumber = (s: string): number | undefined => {
+  if (!s) {
+    return undefined
+  }
+
+  const n = parseInt(s)
+  if (Number.isNaN(n)) {
+    throw new Error('issue-number is an invalid number')
+  }
+  if (!Number.isSafeInteger(n)) {
+    throw new Error('issue-number is not a safe integer')
+  }
+
+  return n
 }
 
 main().catch((e: Error) => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ type Inputs = {
   run: string
   postOnSuccess: string
   postOnFailure: string
+  issueNumber: number | undefined
   token: string
 }
 
@@ -23,6 +24,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
       body: inputs.post,
       updateIfExists: inputs.updateIfExists,
       updateIfExistsKey: inputs.updateIfExistsKey,
+      issueNumber: inputs.issueNumber,
     })
   }
   if (inputs.run) {


### PR DESCRIPTION
Thank you for a very useful action!

In my use case, I need to post a comment on a pull request that is not tied to the current context, and this action fails to infer the target pull request from the context.
To resolve this issue, I would like to add optional `issue-number` input to this action that specifies the target issue or pull request.